### PR TITLE
Clarify practitioner DDD workshop delta and timeboxing

### DIFF
--- a/knowledge/raw-notes/rn-20260726-001.md
+++ b/knowledge/raw-notes/rn-20260726-001.md
@@ -14,20 +14,28 @@ topics: [ddd, workshop, boundary-design]
 
 ## Note
 
-A DDD workshop may intentionally use low-fidelity heuristics so that
-participants can externalize business knowledge, propose provisional boundaries,
-name them, and revisit them without becoming blocked by finding a correct answer.
+A DDD workshop may intentionally define a minimum assurance baseline so that
+participants without prior workshop experience can externalize business
+knowledge, propose provisional boundaries, test them, and retain unresolved
+hypotheses.
 
-This teaching approach does not represent the practitioner's complete
-architecture-design process.
+The baseline deliberately omits some experience-based reasoning that a novice
+is unlikely to generate reliably. This does not make the workshop incomplete
+for its intended purpose, and it does not represent the practitioner's complete
+process when personally owning the design.
 
-When acting as the architecture-design owner, boundary hypotheses are informed
-by prior assessment, business architecture, expected business change, required
-domain knowledge, team cognitive load, integration behavior, and operational
-constraints.
+When acting as the design owner, the practitioner supplements the baseline with
+prior assessment, Business Architecture, expected business change, required
+Domain Knowledge, team cognitive load, Integration behavior, and operational
+constraints. These additions are used to make the first boundary proposal more
+plausible before proceeding.
 
-Workshop artifacts must therefore not be treated as complete evidence of the
-practitioner's design principles.
+The improved proposal remains a hypothesis. Practitioner experience does not
+remove the need for Domain Expert review, alternative representations, PoC,
+implementation feedback, or operational validation.
+
+Source `src-20260726-002` identifies the workshop baseline against which this
+collection records practitioner differences.
 
 ## Questions
 
@@ -41,4 +49,8 @@ this note.
 
 ## Corrections
 
-None recorded.
+- 2026-07-27: Clarified that the workshop is a minimum-assurance baseline for
+  inexperienced participants, while the Raw Note collection records
+  experience-based additions used to refine the initial proposal. The earlier
+  wording could be read as a comparison between a low-fidelity workshop and a
+  complete Architecture Review method.

--- a/knowledge/raw-notes/rn-20260726-001.md
+++ b/knowledge/raw-notes/rn-20260726-001.md
@@ -24,15 +24,52 @@ is unlikely to generate reliably. This does not make the workshop incomplete
 for its intended purpose, and it does not represent the practitioner's complete
 process when personally owning the design.
 
-When acting as the design owner, the practitioner supplements the baseline with
-prior assessment, Business Architecture, expected business change, required
-Domain Knowledge, team cognitive load, Integration behavior, and operational
-constraints. These additions are used to make the first boundary proposal more
-plausible before proceeding.
+The main differences are concentrated before and during initial Microservice
+decomposition.
+
+### Preparation Before the Workshop
+
+When acting as the design owner, the practitioner secures enough information to
+form preliminary hypotheses before the session. This includes:
+
+- the Architecture Vision and the circumstances that produced it;
+- incident trends and operational concerns;
+- capacity characteristics;
+- code coupling and other system-assessment evidence; and
+- relevant business needs and their context.
+
+### Preliminary Value Stream and Responsibility Hypotheses
+
+The practitioner anticipates the likely Value Streams that may appear in the
+session, the types of Domain Experts associated with them, and the
+Responsibilities those experts may own.
+
+These are not conclusions to impose on participants. They allow the
+practitioner to recognize missing participants, implausible responsibility
+placement, and important questions while the workshop is running.
+
+### Explainable Initial Microservice Decomposition
+
+Momentum and provisional placement remain useful during Microservice
+decomposition. The practitioner also compares each emerging Boundary with the
+business needs and context collected so far, and checks that the reason for the
+split can be explained.
+
+This explanation requirement is substantially reduced in the minimum-assurance
+workshop because inexperienced participants may not yet have enough knowledge
+or judgment to explain a reliable Boundary rationale.
+
+### Shared Work After the Initial Proposal
+
+The practitioner and minimum-assurance workshop then perform substantially the
+same forms of Data Model organization and Boundary validation. Experience may
+improve the initial proposal, but it does not make those activities optional.
 
 The improved proposal remains a hypothesis. Practitioner experience does not
 remove the need for Domain Expert review, alternative representations, PoC,
 implementation feedback, or operational validation.
+
+Many omissions and incorrect assumptions are still expected after this work.
 
 Source `src-20260726-002` identifies the workshop baseline against which this
 collection records practitioner differences.
@@ -54,3 +91,8 @@ this note.
   experience-based additions used to refine the initial proposal. The earlier
   wording could be read as a comparison between a low-fidelity workshop and a
   complete Architecture Review method.
+- 2026-07-27: Specified that the primary differences are pre-session evidence,
+  preliminary Value Stream and Domain Expert responsibility hypotheses, and an
+  explainable initial Microservice decomposition. Data Model organization and
+  later validation remain shared activities, and substantial omissions remain
+  possible in both approaches.

--- a/knowledge/raw-notes/rn-20260726-003.md
+++ b/knowledge/raw-notes/rn-20260726-003.md
@@ -14,8 +14,9 @@ topics: [vision, operating-model, business-architecture]
 
 ## Note
 
-When acting as the design owner, the practitioner does not begin with
-application or microservice decomposition.
+Before entering the workshop's Application or Microservice decomposition, the
+practitioner adds design-owner preparation that establishes the intended future
+and its feasibility.
 
 The reasoning begins with the desired future, the operating model required to
 sustain that future, and the business capabilities that the operating model
@@ -26,8 +27,9 @@ Operating-model questions include who defines normal operation, who observes
 deviation, who makes corrective decisions, what can be automated, what must be
 escalated, and how operational learning returns to architecture decisions.
 
-The relevant feasibility question is not only whether an architecture can be
-built. It is also whether the organization can continuously maintain it in an
+For the workshop's boundary proposal, the relevant feasibility question is not
+only whether the proposed Microservices can be built. It is also whether the
+organization can continuously maintain the resulting operating model in an
 acceptable state.
 
 ## Questions
@@ -42,4 +44,6 @@ this note.
 
 ## Corrections
 
-None recorded.
+- 2026-07-27: Narrowed the note from Architecture Reasoning in general to the
+  additional preparation used before workshop boundary formation. The
+  practitioner statement remains unchanged in substance.

--- a/knowledge/raw-notes/rn-20260726-008.md
+++ b/knowledge/raw-notes/rn-20260726-008.md
@@ -17,6 +17,10 @@ topics: [architecture-decision, trade-off, complexity]
 A practitioner design principle is that architecture decisions do not eliminate
 complexity. They determine where, when, and by whom the complexity is carried.
 
+This is a cross-cutting practitioner design principle. It is retained as an
+independent Raw Note and is not asserted to be a difference from the DDD
+workshop baseline in `src-20260726-002`.
+
 A choice may move complexity between design time and runtime, applications and
 platforms, code and configuration, synchronous coordination and asynchronous
 consistency, central teams and product teams, or present simplicity and future
@@ -48,4 +52,5 @@ examples rather than folding them into this principle.
 
 ## Corrections
 
-None recorded.
+- 2026-07-27: Clarified that this is an independent, cross-cutting design
+  principle rather than part of the DDD workshop-difference collection.

--- a/knowledge/raw-notes/rn-20260726-027.md
+++ b/knowledge/raw-notes/rn-20260726-027.md
@@ -12,7 +12,7 @@ topics:
   - topology
   - static-analysis
   - socio-technical
-  - architecture-review
+  - post-workshop-validation
 ---
 
 # Responsibility Concentration Is Observed Across Design, Code, Runtime, and Work
@@ -46,9 +46,10 @@ Before production operation, CI static analysis and code-complexity evidence may
 expose early signs that responsibilities or decisions are accumulating in one
 implementation area.
 
-The practitioner expects GenAI-assisted Architecture Review to help relate these
-implementation signals back to Architecture boundaries and design reasoning.
-This is an expected capability, not a validated automated-review method.
+These implementation signals are compared with the workshop's Context Map and
+Boundary reasoning. They provide later evidence for validating or revisiting the
+initial hypothesis; they are not treated as a separate Architecture Review
+method in this note.
 
 ## Work and Communication
 
@@ -68,8 +69,6 @@ the intended responsibility and Context Map.
 - Which topology, load, and connection patterns indicate inappropriate
   concentration rather than legitimate demand?
 - Which communication-path and backlog patterns suggest a boundary problem?
-- How should GenAI relate CI findings to Architecture artifacts without
-  presenting inference as fact?
 
 ## Next Steps
 
@@ -78,4 +77,8 @@ socio-technical evidence surfaces.
 
 ## Corrections
 
-None recorded.
+- 2026-07-27: Removed the expectation for GenAI-assisted Architecture Review
+  from this DDD collection note. That expectation arose in the interview but is
+  Architecture Review product knowledge rather than a difference from the
+  workshop baseline. The remaining material is scoped to post-workshop
+  validation of the initial Boundary hypothesis.

--- a/knowledge/raw-notes/rn-20260726-031.md
+++ b/knowledge/raw-notes/rn-20260726-031.md
@@ -56,8 +56,10 @@ Advanced practitioner behavior
   -> move repeatedly between Business and Technology Architecture
 ```
 
-Reducing the frequency or depth of BAU trace-back may be appropriate for a
-general method, but the conditions for doing so have not yet been defined.
+Reducing the frequency or depth of BAU trace-back may be appropriate when
+turning this practitioner overlay into a workshop method usable by less
+Business-Architecture-oriented facilitators, but the conditions for doing so
+have not yet been defined.
 
 ## Questions
 
@@ -70,9 +72,9 @@ general method, but the conditions for doing so have not yet been defined.
 
 ## Next Steps
 
-Develop a Candidate tiered review method from these questions. Do not present
-such a method as the practitioner's established process until it has been
-reviewed and tested.
+Develop a Candidate tiered boundary-validation method from these questions. Do
+not generalize it into an Architecture Review method or present it as the
+practitioner's established process until it has been reviewed and tested.
 
 ## Corrections
 
@@ -81,3 +83,6 @@ reviewed and tested.
   Deep Business Architecture trace-back is primarily required when a decision
   is both a One-way Door and important to the Architecture Vision. See
   `rn-20260726-032`.
+- 2026-07-27: Narrowed the proposed downstream method to DDD and Microservice
+  Boundary validation. The interview did not establish a general Architecture
+  Review method.

--- a/knowledge/raw-notes/rn-20260726-032.md
+++ b/knowledge/raw-notes/rn-20260726-032.md
@@ -48,7 +48,8 @@ approach must also permit the decision to be revised when evidence appears. See
 `rn-20260726-033`.
 
 This principle changes the frequency of Business Architecture trace-back while
-forming and validating the Boundary proposal:
+forming and validating the Boundary proposal. It also determines how the
+limited workshop and design timebox is allocated; see `rn-20260727-034`.
 
 ```text
 One-way Door
@@ -88,3 +89,6 @@ technical symptoms as investigation signals within that decision frame.
 - 2026-07-27: Restricted the claim to Microservice Boundary and decomposition
   decisions. The interview context did not establish the same prioritization as
   a rule for every Architecture Review decision.
+- 2026-07-27: Clarified that reversibility and Architecture Vision importance
+  also allocate the validation timebox, not only the depth of Business
+  Architecture trace-back. See `rn-20260727-034`.

--- a/knowledge/raw-notes/rn-20260726-032.md
+++ b/knowledge/raw-notes/rn-20260726-032.md
@@ -15,14 +15,15 @@ topics:
   - observability
 ---
 
-# BA Trace-Back Is Prioritized by Reversibility and Vision Importance
+# BA Trace-Back for Boundary Decisions Is Prioritized by Reversibility and Vision Importance
 
 ## Note
 
 This note corrects and extends `rn-20260726-031`.
 
-Frequent traversal between Business Architecture and Technology Architecture is
-not required for every Architecture Decision.
+Within the workshop-difference context, frequent traversal between Business
+Architecture and Technology Architecture is not required for every
+Microservice Boundary or decomposition decision.
 
 The practitioner considers deep Business Architecture trace-back necessary when
 a decision satisfies both conditions:
@@ -30,9 +31,9 @@ a decision satisfies both conditions:
 1. it is a One-way Door or otherwise difficult to reverse; and
 2. it is important to realizing the Architecture Vision.
 
-For a Two-way Door decision, incomplete Business Architecture analysis can be
-acceptable when the design makes a missed assumption observable and the
-decision can be corrected after evidence appears.
+For a Two-way Door Boundary decision, incomplete Business Architecture analysis
+can be acceptable when the design makes a missed assumption observable and the
+Boundary can be corrected after evidence appears.
 
 The objective is not to eliminate every possible design error before
 implementation. Reversible decisions may be made with remaining uncertainty
@@ -46,7 +47,8 @@ Technical reversibility is not sufficient. The organization and delivery
 approach must also permit the decision to be revised when evidence appears. See
 `rn-20260726-033`.
 
-This principle changes the frequency of Business Architecture trace-back:
+This principle changes the frequency of Business Architecture trace-back while
+forming and validating the Boundary proposal:
 
 ```text
 One-way Door
@@ -64,7 +66,7 @@ method.
 
 ## Questions
 
-- What makes a decision effectively irreversible in Architecture practice?
+- What makes a Boundary decision effectively irreversible in this workflow?
 - Which Observability signals are sufficient for a particular Two-way Door?
 - How much correction cost can a decision carry before it stops being a
   practical Two-way Door?
@@ -74,8 +76,8 @@ method.
 ## Next Steps
 
 Use reversibility and Architecture Vision importance as primary dimensions when
-developing the Candidate tiered review method. Treat individual technical
-symptoms as investigation signals within that decision frame.
+developing the Candidate tiered boundary-validation method. Treat individual
+technical symptoms as investigation signals within that decision frame.
 
 ## Corrections
 
@@ -83,3 +85,6 @@ symptoms as investigation signals within that decision frame.
   correction are required for a decision to function as a Two-way Door. A
   technically reversible decision can be operationally irreversible when the
   organization resists revision. See `rn-20260726-033`.
+- 2026-07-27: Restricted the claim to Microservice Boundary and decomposition
+  decisions. The interview context did not establish the same prioritization as
+  a rule for every Architecture Review decision.

--- a/knowledge/raw-notes/rn-20260726-033.md
+++ b/knowledge/raw-notes/rn-20260726-033.md
@@ -15,14 +15,14 @@ topics:
   - correction
 ---
 
-# Two-Way Doors Require Organizational Permission to Correct
+# Two-Way-Door Boundary Hypotheses Require Organizational Permission to Correct
 
 ## Note
 
 This note extends `rn-20260726-032`.
 
-A technically reversible Architecture Decision does not automatically function
-as a Two-way Door.
+A technically reversible Microservice Boundary decision does not automatically
+function as a Two-way Door in this workflow.
 
 The organization and delivery approach must accept that the initial decision is
 a hypothesis that may be corrected after implementation evidence appears. If
@@ -49,8 +49,8 @@ possibility of correction.
 This cause is a practitioner hypothesis rather than a universal explanation for
 organizational resistance.
 
-A project using Two-way Door reasoning should make the following explicit before
-commitment:
+A project using Two-way Door reasoning for a Boundary hypothesis should make
+the following explicit before commitment:
 
 - which assumptions remain uncertain;
 - which observations will test them;
@@ -70,9 +70,11 @@ the lighter validation treatment intended for a Two-way Door.
 
 ## Next Steps
 
-Include organizational reversibility in any Candidate review method based on
-One-way and Two-way Doors.
+Include organizational reversibility in any Candidate boundary-validation
+method based on One-way and Two-way Doors.
 
 ## Corrections
 
-None recorded.
+- 2026-07-27: Restricted the claim to the organizational correction of
+  Microservice Boundary hypotheses. The prior wording could be read as a
+  universal Architecture Decision or Architecture Review rule.

--- a/knowledge/raw-notes/rn-20260727-034.md
+++ b/knowledge/raw-notes/rn-20260727-034.md
@@ -1,0 +1,84 @@
+---
+id: rn-20260727-034
+type: raw_note
+maturity: raw
+review_usage: prohibited
+created_at: 2026-07-27
+note_kind: practitioner_reasoning
+source_mode: practitioner_reasoning
+confidentiality: public_safe
+topics:
+  - ddd
+  - microservice-boundary
+  - reversibility
+  - timebox
+  - architecture-vision
+  - validation
+---
+
+# Reversibility Determines Validation Timebox Allocation
+
+## Note
+
+This note extends `rn-20260726-032` and `rn-20260726-033`.
+
+One-way Door and Two-way Door reasoning is important not only for deciding
+whether to perform deeper Business Architecture trace-back. It is also a
+principle for allocating limited workshop and design time.
+
+The practitioner does not attempt to give every Boundary hypothesis the same
+analysis depth.
+
+A decision that is difficult to reverse and important to the Architecture
+Vision receives more time before commitment. The workshop should seek stronger
+evidence, make the Boundary rationale explainable, and reduce important
+uncertainty while correction remains inexpensive.
+
+A reversible decision may receive a smaller pre-commitment timebox when:
+
+- remaining assumptions are explicit;
+- the consequences are observable;
+- a practical correction path exists; and
+- the organization permits the hypothesis to be revised.
+
+This does not mean that Two-way Door decisions require no validation. It means
+that some validation can be deferred to implementation or operation instead of
+consuming the workshop timebox.
+
+The timebox principle can be summarized as:
+
+```text
+Irreversible
++ important to Architecture Vision
+  -> spend analysis time before commitment
+
+Reversible
++ observable
++ correctable in practice
+  -> bound pre-commitment analysis
+  -> preserve the hypothesis
+  -> validate through later evidence
+```
+
+The objective is to spend scarce analysis time where an incorrect assumption
+would be both important and expensive to correct. It is not to claim that an
+experienced practitioner can eliminate omissions. Data Model organization and
+the applicable Boundary-validation activities remain necessary.
+
+## Questions
+
+- How should a facilitator estimate whether a Boundary is genuinely
+  reversible?
+- What minimum validation remains mandatory for a Two-way Door decision?
+- How should the workshop make deferred validation and its owner visible?
+- When does accumulated correction cost invalidate the smaller timebox?
+
+## Next Steps
+
+Use this principle when developing a timeboxed workshop method from the
+practitioner overlay. Preserve explicit links from deferred validation to PoC,
+implementation evidence, or operational Observability.
+
+## Corrections
+
+None recorded.

--- a/knowledge/sources/src-20260726-002.md
+++ b/knowledge/sources/src-20260726-002.md
@@ -41,6 +41,7 @@ related_assets:
   - rn-20260726-031
   - rn-20260726-032
   - rn-20260726-033
+  - rn-20260727-034
 ---
 
 # Source Anchor
@@ -70,6 +71,8 @@ The related Raw Notes record the practitioner's additions to that baseline:
   Responsibilities;
 - checking that an initial Microservice split is explainable from the collected
   business needs and context.
+- allocating limited validation time according to reversibility and importance
+  to the Architecture Vision.
 
 The practitioner and workshop baseline both retain Data Model organization and
 Boundary validation. Experience may improve the initial proposal, but it does

--- a/knowledge/sources/src-20260726-002.md
+++ b/knowledge/sources/src-20260726-002.md
@@ -63,9 +63,17 @@ workshop experience. It deliberately does not require every experience-based
 heuristic that the practitioner uses when personally owning the design.
 
 The related Raw Notes record the practitioner's additions to that baseline:
-evidence and preliminary hypotheses used to improve an initial Microservice
-Boundary proposal before the workshop proceeds, without removing the need for
-later falsification and validation.
+
+- securing Architecture Vision, operational, capacity, code-coupling, and
+  business-context evidence before the session;
+- anticipating likely Value Streams, Domain Expert types, and their
+  Responsibilities;
+- checking that an initial Microservice split is explainable from the collected
+  business needs and context.
+
+The practitioner and workshop baseline both retain Data Model organization and
+Boundary validation. Experience may improve the initial proposal, but it does
+not remove the need for later falsification, and many omissions may remain.
 
 `rn-20260726-008` is intentionally not related as a workshop-difference note. It
 records a cross-cutting practitioner design principle that arose during the

--- a/knowledge/sources/src-20260726-002.md
+++ b/knowledge/sources/src-20260726-002.md
@@ -9,8 +9,38 @@ published_at: 2026-07-24
 retrieved_at: 2026-07-26
 url: https://note.com/skijima/n/n13533c4cdf48
 related_assets:
+  - rn-20260726-001
+  - rn-20260726-002
+  - rn-20260726-003
+  - rn-20260726-004
+  - rn-20260726-005
+  - rn-20260726-006
+  - rn-20260726-007
+  - rn-20260726-009
+  - rn-20260726-010
+  - rn-20260726-011
+  - rn-20260726-012
+  - rn-20260726-013
+  - rn-20260726-014
+  - rn-20260726-015
+  - rn-20260726-016
+  - rn-20260726-017
+  - rn-20260726-018
+  - rn-20260726-019
+  - rn-20260726-020
+  - rn-20260726-021
+  - rn-20260726-022
+  - rn-20260726-023
+  - rn-20260726-024
+  - rn-20260726-025
   - rn-20260726-026
   - rn-20260726-027
+  - rn-20260726-028
+  - rn-20260726-029
+  - rn-20260726-030
+  - rn-20260726-031
+  - rn-20260726-032
+  - rn-20260726-033
 ---
 
 # Source Anchor
@@ -27,7 +57,19 @@ related_assets:
 
 ## Verification Use
 
-Use this source to verify the practitioner's published workshop design for
-forming and falsifying Microservice Boundary hypotheses before implementation.
+Use this source as the baseline for the DDD interview collection. The workshop
+is designed to provide a minimum assurance level for participants without prior
+workshop experience. It deliberately does not require every experience-based
+heuristic that the practitioner uses when personally owning the design.
+
+The related Raw Notes record the practitioner's additions to that baseline:
+evidence and preliminary hypotheses used to improve an initial Microservice
+Boundary proposal before the workshop proceeds, without removing the need for
+later falsification and validation.
+
+`rn-20260726-008` is intentionally not related as a workshop-difference note. It
+records a cross-cutting practitioner design principle that arose during the
+same collection.
+
 Do not treat the article as Curated Knowledge or as automatic Production Review
 guidance.


### PR DESCRIPTION
## What changed

- Clarified that the DDD Raw Note collection records an experienced
  practitioner's additions to the minimum-assurance workshop baseline.
- Defined the main differences as pre-session evidence, preliminary Value
  Stream and Domain Expert responsibility hypotheses, and explainable initial
  Microservice decomposition.
- Removed a GenAI Architecture Review product expectation that had been mixed
  into the DDD collection.
- Restricted One-way Door and Two-way Door claims to Microservice Boundary
  validation in this interview context.
- Added `rn-20260727-034` to preserve reversibility as a principle for allocating
  the workshop and design validation timebox.
- Expanded the workshop source anchor and appended Raw Note correction history.

## Why

The original interview summary blurred three different scopes: the published
workshop baseline, the practitioner's experience-based overlay, and general
Architecture Review knowledge. This change restores the intended provenance and
applicability boundaries without discarding valid practitioner reasoning.

## Impact

The Raw Notes now make clear which reasoning improves the initial Boundary
hypothesis and which validation activities remain shared with the workshop
baseline. These assets remain unverified Raw Notes and prohibited in Production
Review.

## Validation

- `python3 scripts/validate_repository.py`
- Result: 59 Failure Model nodes and 34 Raw Notes validated successfully.
- `git diff --check origin/main...HEAD`
